### PR TITLE
Use "jsdoc-api" lib instead of "jsdoc" cli

### DIFF
--- a/lib/docs/config.js
+++ b/lib/docs/config.js
@@ -3,7 +3,8 @@
 var THIRD_PARTY_JSON_NAMESPACE = 'inch',
     fs = require('fs'),
     jsyaml = require('js-yaml'),
-    Path = require('path');
+    Path = require('path'),
+    glob = require('glob');
 
 function get() {
   return loadJsonConfig('inch.json') ||
@@ -14,7 +15,35 @@ function get() {
 }
 
 function files() {
-  return get().files || {};
+  var files = get().files || {};
+  return {
+    files: files,
+    resolvedFiles: resolveFiles(files)
+  };
+}
+
+function resolveFiles(files) {
+  // Contiue if we have "included" files
+  if (files.included) {
+    var includedFiles = files.included.reduce(function(resolvedFiles, file) {
+      return resolvedFiles.concat(glob.sync(getLocalFilename(file), { nodir: true }));
+    }, []);
+
+    // If we have "excluded" files, so we need to filter them out
+    if (files.excluded) {
+      var excludedFiles = files.excluded.reduce(function(resolvedFiles, file) {
+        return resolvedFiles.concat(glob.sync(getLocalFilename(file), { nodir: true }));
+      }, []);
+
+      return includedFiles.filter(function(file) {
+        return excludedFiles.indexOf(file) === -1;
+      });
+    } else {
+      return includedFiles;
+    }
+  } else {
+    return [];
+  }
 }
 
 function loadJsonConfig(_filename, namespace) {

--- a/lib/docs/jsdoc_runner.js
+++ b/lib/docs/jsdoc_runner.js
@@ -2,66 +2,24 @@
 
 var formatter = require('./formatter.js'),
     retriever = require('./retriever.js'),
-    fs = require('fs'),
-    sh = require('shelljs'),
-    Path = require('path'),
-    exec = require('child_process').exec;
+    config = require('./config'),
+    jsdoc = require('jsdoc-api');
 
 function run(jsdoc_args, callback) {
-  checkJSDocExistance();
+  var filesConfig = config.files();
 
-  jsdoc_args = jsdoc_args || [];
-
-  if( jsdoc_args.length == 0 && retriever.getIncluded().length == 0 ) {
+  if(filesConfig.files.length === 0) {
     fail("No sources found.");
   }
 
-  var jsdoc_options = "--explain --lenient --recurse --configure "+getJSDocConfigFilename();
-
-  var filename = "docs.json",
-      cmd = "jsdoc " + jsdoc_args.join(' ') + " " + jsdoc_options;
-
-  var child = sh.exec(cmd, {silent: true, async: true});
-  var output = "";
-  child.stdout.on('data', function(data) {
-    output += data;
-  });
-  child.stdout.on('close', function() {
-    try {
-      var objects = JSON.parse( output );
-    } catch(e) {
-      console.log(output);
-      fail("Parsing failed.")
-    }
-    var data = formatter.run(objects, []);
-    fs.writeFileSync(filename, JSON.stringify(data));
-    callback(filename);
-  });
+  var objects = jsdoc.explainSync({ files: filesConfig.resolvedFiles });
+  var formatted = formatter.run(objects, []);
+  callback(formatted);
 }
 
 function fail(msg) {
   console.error('[InchJS] '+msg);
   process.exit(1);
-}
-
-function checkJSDocExistance() {
-  try {
-    require('jsdoc/package.json');
-  } catch(e) {
-    throw("Could not find jsdoc executable");
-  }
-}
-
-function getJSDocConfigFilename() {
-  var filename = ".inch.config.json";
-  var data = {
-    "source": {
-      "include": retriever.getIncluded(),
-      "exclude": retriever.getExcluded()
-    }
-  }
-  fs.writeFileSync(filename, JSON.stringify(data));
-  return filename;
 }
 
 module.exports = {

--- a/lib/reporter/local.js
+++ b/lib/reporter/local.js
@@ -8,21 +8,22 @@ var sh = require('shelljs'),
 
 var CLI_API_END_POINT = 'https://inch-ci.org/api/v1/cli'
 
-function run(inch_args, filename, callback) {
+function run(inch_args, data, callback) {
   inch_args = inch_args || [];
   if( hasLocalInch() ) {
+    var filename = 'docs.json';
+    fs.writeFileSync(filename, JSON.stringify(data));
     var default_args = ["--language=javascript", "--read-from-dump="+filename];
     runLocalInch(inch_args.concat(default_args), callback)
   } else {
-    runApiInch(inch_args, filename);
+    runApiInch(inch_args, data);
   }
 }
 
-function runApiInch(inch_args, filename) {
+function runApiInch(inch_args, data) {
   inch_args = inch_args || [];
-  var json = JSON.parse( fs.readFileSync(filename) );
-  json['args'] = inch_args;
-  var data = JSON.stringify(json);
+  data['args'] = inch_args;
+  var dataString = JSON.stringify(data);
   var url = require('url').parse(getInchCliEndPoint());
   var options = {
     host: url.hostname,
@@ -31,7 +32,7 @@ function runApiInch(inch_args, filename) {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'Content-Length': Buffer.byteLength(data, 'utf8')
+      'Content-Length': Buffer.byteLength(dataString, 'utf8')
     }
   };
 
@@ -47,7 +48,7 @@ function runApiInch(inch_args, filename) {
   });
 
   // write data to request body
-  req.write(data);
+  req.write(dataString);
   req.end();
 }
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "glob": "4.3.5",
     "js-yaml": "^3.3.1",
-    "jsdoc": "3.x",
+    "jsdoc-api": "^2.0.6",
     "shelljs": "0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
#### Changes/Fixes:

- Much faster, from **(76 sec)** to **(4 sec)** *(for the same included/excluded files)*
- Use **jsdoc-api** instead of **jsdoc**
- Only create `docs.json` in case of having *inch* running locally
- `local.runApiInch` method now accepting `JSON` formatted data (instead of filename)

---

Closes #18, #19 