### PR TITLE
print received api chunks with no lf

### DIFF
--- a/lib/reporter/local.js
+++ b/lib/reporter/local.js
@@ -38,7 +38,7 @@ function runApiInch(inch_args, filename) {
   var req = https.request(options, function(res) {
     res.setEncoding('utf8');
     res.on('data', function (chunk) {
-      console.log(chunk);
+      process.stdout.write(chunk);
     });
   });
 


### PR DESCRIPTION
This PR fixes the local reporter when printing the received chunks.

It uses `console.log`, which prints new lines (line feeds) after each received chunk, producing this output:

![screenshot-bad](https://user-images.githubusercontent.com/10707639/35996363-a2d0dac2-0d16-11e8-8af4-cec3cafcddfc.png)

See the truncated line at the end of the **U** list (`de\nactivate`). This PR fixes that printing, making it looks like this:

![screenshot-good](https://user-images.githubusercontent.com/10707639/35996393-b1f93486-0d16-11e8-90a0-18214852aaa8.png)